### PR TITLE
ダブルクリックでコメントを表示する機能を改善

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -56,6 +56,10 @@
             background-color: #e3f2fd;
         }
 
+        .comment-item.displayed {
+            background-color: #fff3e0;
+        }
+
         .author-icon {
             width: 40px;
             height: 40px;
@@ -115,6 +119,7 @@
     <script>
         let comments = [];
         let selectedComment = null;
+        let displayedComment = null;
         let ws = null;
 
         // サーバーのホストアドレスを取得
@@ -171,7 +176,7 @@
             commentList.innerHTML = comments.map((comment, index) => {
                 const iconUrl = (comment.author_icon || 'https://yt3.ggpht.com/ytc/default-avatar.jpg').replace(/\s+/g, '');
                 return `
-                    <div class="comment-item ${selectedComment === index ? 'selected' : ''}" 
+                    <div class="comment-item ${selectedComment === index ? 'selected' : ''} ${displayedComment === index ? 'displayed' : ''}" 
                          onclick="selectComment(${index})" 
                          ondblclick="handleDoubleClick(${index})">
                         <img class="author-icon" src="${escapeHtml(iconUrl)}" 
@@ -210,6 +215,7 @@
             if (selectedComment === null || !ws) return;
             
             const comment = comments[selectedComment];
+            displayedComment = selectedComment;
             ws.send(JSON.stringify({
                 type: 'select_comment',
                 comment: comment
@@ -219,6 +225,7 @@
         function clearDisplay() {
             if (!ws) return;
             
+            displayedComment = null;
             ws.send(JSON.stringify({
                 type: 'select_comment',
                 comment: null

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -239,8 +239,16 @@
         }
 
         function handleDoubleClick(index) {
-            selectComment(index);
-            displaySelectedComment();
+            if (!ws) return;
+            
+            const comment = comments[index];
+            selectedComment = index;
+            displayedComment = index;
+            ws.send(JSON.stringify({
+                type: 'select_comment',
+                comment: comment
+            }));
+            updateCommentList();
         }
     </script>
 </body>

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -173,7 +173,7 @@
                 return `
                     <div class="comment-item ${selectedComment === index ? 'selected' : ''}" 
                          onclick="selectComment(${index})" 
-                         ondblclick="editComment(${index})">
+                         ondblclick="handleDoubleClick(${index})">
                         <img class="author-icon" src="${escapeHtml(iconUrl)}" 
                              onerror="this.src='https://yt3.ggpht.com/ytc/default-avatar.jpg'" 
                              alt="${escapeHtml(comment.author)}">
@@ -229,6 +229,11 @@
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
+        }
+
+        function handleDoubleClick(index) {
+            selectComment(index);
+            displaySelectedComment();
         }
     </script>
 </body>


### PR DESCRIPTION
close #8 

# 変更内容:
* ダブルクリックで選択したコメントがオレンジ色に表示されるように修正しました。
* デバッグ用のログ表示を削除し、コードをクリーンにしました。

# 変更の理由:
* ユーザーがコメントをダブルクリックした際に、即座に視覚的なフィードバックを提供するための改善です。
* コードの可読性を向上させるために、不要なデバッグログを削除しました。

# 影響:
* コメントの表示がより直感的になり、ユーザーエクスペリエンスが向上します。
* コードのクリーンアップにより、今後のメンテナンスが容易になります。