### PR TITLE
Update fetch interval to use config

### DIFF
--- a/server.py
+++ b/server.py
@@ -126,7 +126,7 @@ class ConnectionManager:
                                 "author_icon": message.get('author_icon', '')
                             }
                         }))
-            await asyncio.sleep(5)  # 5秒待機
+            await asyncio.sleep(app_config.MESSAGE_FETCH_INTERVAL)
 
     async def start_fetching_comments(self):
         """コメント取得タスクを開始"""


### PR DESCRIPTION
## Summary
- server uses `app_config.MESSAGE_FETCH_INTERVAL` for fetch delay

## Testing
- `python test_integration.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*