### PR TITLE
Hide API key in logs

### DIFF
--- a/run.py
+++ b/run.py
@@ -19,7 +19,10 @@ def main():
     print(f"SERVER_HOST: {server_host or '未設定'}")
     print(f"YOUTUBE_API_KEY: {'設定済み' if youtube_api_key else '未設定'}")
     print("==================\n")
-    print(youtube_api_key)
+    if youtube_api_key:
+        print(f"***{youtube_api_key[-5:]}")
+    else:
+        print("未設定")
     # サーバーを起動
     print("FastAPIサーバーを起動します...")
     uvicorn.run(

--- a/run.py
+++ b/run.py
@@ -18,11 +18,10 @@ def main():
 
     print(f"SERVER_HOST: {server_host or '未設定'}")
     print(f"YOUTUBE_API_KEY: {'設定済み' if youtube_api_key else '未設定'}")
-    print("==================\n")
     if youtube_api_key:
-        print(f"***{youtube_api_key[-5:]}")
-    else:
-        print("未設定")
+        print(f"YOUTUBE_API_KEY: ***{youtube_api_key[-5:]}")
+    print("==================\n")
+
     # サーバーを起動
     print("FastAPIサーバーを起動します...")
     uvicorn.run(


### PR DESCRIPTION
## Summary
- keep only the last five characters of the API key in logs

## Testing
- `pytest -q` *(fails: No module named pytest)*